### PR TITLE
Update debian packaging with meson build

### DIFF
--- a/debian/battery-monitor.doc-base
+++ b/debian/battery-monitor.doc-base
@@ -1,0 +1,13 @@
+Document: battery-monitor
+Title: Debian Battery Monitor Manual
+Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
+Abstract: This manual describes what
+ Battery Monitor is and how it can be used
+ to monitor battery present on the system
+ or external devices like attached bluetooth
+ headphones.
+Section: System/Monitoring
+
+Format: HTML
+Index: /usr/share/doc/battery-monitor/html/index.html
+Files: /usr/share/doc/battery-monitor/html/*.html

--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,13 @@ Section: utils
 Priority: optional
 Maintainer: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
 Build-Depends: debhelper-compat (= 13),
+               desktop-file-utils,
                dh-python,
                gettext,
                libglib2.0-bin,
+               libgtk-4-bin,
+               meson,
                python3,
-               python3-setuptools,
                python3-sphinx,
                python3-sphinx-argparse
 Standards-Version: 4.6.0

--- a/debian/rules
+++ b/debian/rules
@@ -3,11 +3,11 @@
 # output every command that modifies files on the build system.
 # export DH_VERBOSE = 1
 
-export PYBUILD_NAME=battery-monitor
-export PYBUILD_INSTALL_ARGS_python3=--install-scripts=usr/bin
+export PYBUILD_SYSTEM=meson
+# export PYBUILD_NAME=battery-monitor
 
 %:
-	dh ${@} --with python3,sphinxdoc --buildsystem=pybuild
+	dh ${@} --with python3,sphinxdoc --buildsystem=meson
 
 
 # If you need to rebuild the Sphinx documentation
@@ -17,17 +17,13 @@ export PYBUILD_INSTALL_ARGS_python3=--install-scripts=usr/bin
 override_dh_auto_build: export http_proxy=127.0.0.1:9
 override_dh_auto_build: export https_proxy=127.0.0.1:9
 override_dh_auto_build:
-	dh_auto_build -O--buildsystem=pybuild
+	dh_auto_build -O--buildsystem=meson
 	PYTHONPATH=. python3 -m sphinx -N -bhtml \
-	docs/ usr/share/html # HTML generator
+	docs/ usr/share/doc/battery-monitor/html # HTML generator
 	PYTHONPATH=. python3 -m sphinx -N -bman \
 	docs/ usr/share/man/man1 # Manpage generator
-	rm -rfv usr/share/html/.doctrees usr/share/man/man1/.doctrees
+	rm -rfv usr/share/doc/battery-monitor/html/.doctrees usr/share/man/man1/.doctrees
 
 override_dh_install:
-	dh_install -O--buildsystem=pybuild
-	install -D -m 0644 data/org.mamolinux.battery-monitor.gschema.xml.in debian/battery-monitor/usr/share/glib-2.0/schemas/org.mamolinux.battery-monitor.gschema.xml
+	dh_install -O--buildsystem=meson
 	install -D -m 0644 data/battery-monitor-autostart.desktop.in debian/battery-monitor/etc/xdg/autostart/battery-monitor-autostart.desktop
-
-override_dh_auto_install:
-	dh_auto_install --destdir=$(CURDIR)/$(DEB_SOURCE) -O--buildsystem=pybuild


### PR DESCRIPTION
- Use meson buildsystem for debian packaging
- Update doc-base to remove lintian
- Add meson build dependencies
